### PR TITLE
fix(model.js): correct default signmethod comments

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -103,7 +103,7 @@ export default class Model {
    * Username: deviceName+"&"+productKey 
    * Password: sign_hmac(deviceSecret,content)
    * securemode：表示目前安全模式，可选值有2 （TLS直连模式）和3（TCP直连模式）
-   * signmethod：签名算法，支持hmacmd5，hmacsha1，hmacsha256和 sha256，默认为hmacmd5。
+   * signmethod：签名算法，支持hmacmd5，hmacsha1，hmacsha256和 sha256，默认为 hmacsha1。
    * timestamp: 可选
    */
   genConnectPrarms1() {


### PR DESCRIPTION
signmethod default is hmacsha1, according to [the source code here](https://github.com/aliyun/alibabacloud-iot-device-sdk/blob/2e20bc0d0371d394bc7f22deb2f570bc9a110d59/src/model.js#L217).